### PR TITLE
Email format

### DIFF
--- a/iam/verify.py
+++ b/iam/verify.py
@@ -360,7 +360,7 @@ async def state_await_zid(db, mail, member, member_data, zid):
         await member.send("Your zID must match the following format: "
             "`zXXXXXXX`. Please try again")
         return
-    email = f"{zid}@student.unsw.edu.au"
+    email = f"{zid}@unsw.edu.au"
 
     db.update_member_data(member.id, {
         MemberKey.ZID: zid,
@@ -453,7 +453,7 @@ async def proc_request_code(db, member):
         member: Member object to make request to.
     """
     await member.send("Please enter the code sent to your email. If you are a "
-        "UNSW student, this is your zID@student.unsw.edu.au email. Please "
+        "UNSW student, this is your zID@unsw.edu.au email. Please "
         "check your spam folder if you don't see it.\n"
         f"You can request another email by typing `{PREFIX}resend`.")
 
@@ -726,7 +726,7 @@ async def proc_verify_manual(db, ver_role, channel, join_announce_channel,
     if is_valid_zid(arg):
         member_data.update({
             MemberKey.ZID: arg, 
-            MemberKey.EMAIL: f"{arg}@student.unsw.edu.au"
+            MemberKey.EMAIL: f"{arg}@unsw.edu.au"
         })
     elif is_valid_email(arg):
         member_data.update({MemberKey.EMAIL: arg})

--- a/test_verify.py
+++ b/test_verify.py
@@ -24,7 +24,7 @@ VALID_ZIDS = ["z5555555", "z1234567", "z0000000", "z5242579"]
 INVALID_ZIDS = ["5555555", "z12345678", "z0", "5242579z"]
 VALID_EMAILS = [
     "thesabinelim@gmail.com", "arcdelegate@unswpcsoc.com",
-    "sabine.lim@unsw.edu.au", "z5242579@student.unsw.edu.au", "g@g.gg"
+    "sabine.lim@unsw.edu.au", "z5242579@unsw.edu.au", "g@g.gg"
 ]
 INVALID_EMAILS = ["a@a", "google.com", "email", "", "@gmail.com", "hi@"]
 SAMPLE_CODES = ["cf137a", "000000", "hello_world"]
@@ -419,7 +419,7 @@ async def test_state_await_zid_standard():
         mail = MagicMock()
         member = new_mock_user(0)
         member_data = make_def_member_data()
-        email = f"{zid}@student.unsw.edu.au"
+        email = f"{zid}@unsw.edu.au"
 
         # Call
         with patch("iam.verify.proc_send_email") as mock_proc_send_email:
@@ -449,7 +449,7 @@ async def test_state_await_zid_invalid():
         mail = MagicMock()
         member = new_mock_user(0)
         member_data = make_def_member_data()
-        email = f"{zid}@student.unsw.edu.au"
+        email = f"{zid}@unsw.edu.au"
 
         # Call
         with patch("iam.verify.proc_send_email") as mock_proc_send_email:
@@ -1352,7 +1352,7 @@ async def test_proc_verify_manual_unsw_standard():
             member_data[MemberKey.EMAIL_VER] = True
             member_data[MemberKey.ID_VER] = True
             member_data[MemberKey.VER_EXEC] = exec.id
-            member_data[MemberKey.EMAIL] = f"{zid}@student.unsw.edu.au"
+            member_data[MemberKey.EMAIL] = f"{zid}@unsw.edu.au"
             db.set_member_data.assert_called_once()
             call_args = db.set_member_data.call_args.args
             assert call_args[0] == member.id


### PR DESCRIPTION
Change email format to z5555555@unsw.edu.au so staff can use the zID route as well.
z5555555@student.unsw.edu.au only works for students.